### PR TITLE
deal better with retreat

### DIFF
--- a/src/main/groovy/fish/ed/EDSM.groovy
+++ b/src/main/groovy/fish/ed/EDSM.groovy
@@ -55,7 +55,6 @@ class EDSM {
 				influencesGroupedByDate.put(latestDate, [f.influence])
 			}
 			// this may store factions where they are no longer active, but the current dates would hold no values.
-			String state = f.state
 			if (f.influence < 0.000001) {
 				f.state = "Gone"
 			}

--- a/src/main/groovy/fish/ed/EDSM.groovy
+++ b/src/main/groovy/fish/ed/EDSM.groovy
@@ -55,6 +55,10 @@ class EDSM {
 				influencesGroupedByDate.put(latestDate, [f.influence])
 			}
 			// this may store factions where they are no longer active, but the current dates would hold no values.
+			String state = f.state
+			if (f.influence < 0.000001) {
+				f.state = "Gone"
+			}
 			if (influencesGroupedByDate) {
 				factionData += [
 					name            : f.name,

--- a/src/main/groovy/fish/ed/FactionStatsOutput.groovy
+++ b/src/main/groovy/fish/ed/FactionStatsOutput.groovy
@@ -137,17 +137,21 @@ class FactionStatsOutput {
 				displayFactionLeads(factionName, todayDate, systemName, edsmDataForSystem)
 			}
 		}
-
 	}
 
 	def displayFactionsInSystem(String factionName, LocalDate todayDate, boolean showAllFactions, String systemName, long population, List<Map> edsmDataForSystem) {
 		boolean hasShownMainFaction = false
-		edsmDataForSystem.eachWithIndex { Map factionData, int i ->
+		LocalDate fromDate = LocalDate.of(1900, 1, 1)
+		edsmDataForSystem.each { Map factionData ->
+            if (factionData.currentDate.isAfter(fromDate)) {
+				fromDate = factionData.currentDate
+			}
+		}
+		LocalDate d1Date = fromDate.minusDays(1)
+		LocalDate d3Date = fromDate.minusDays(3)
+		LocalDate d7Date = fromDate.minusDays(7)
 
-			LocalDate fromDate = calculateFromDate(todayDate, factionData)
-			LocalDate d1Date = calculateFromDate(fromDate.minusDays(1), factionData)
-			LocalDate d3Date = calculateFromDate(fromDate.minusDays(3), factionData)
-			LocalDate d7Date = calculateFromDate(fromDate.minusDays(7), factionData)
+		edsmDataForSystem.eachWithIndex { Map factionData, int i ->
 
 			if (i == 0) {
 				def headingString = sprintf('%-41s %6s %6s %6s %6s',
@@ -181,6 +185,8 @@ class FactionStatsOutput {
 			}
 
 			if (debugOutput) {
+				println "todayDate: ${todayDate}"
+				println "fromDate: ${fromDate}"
 				println "system : ${systemName}"
 				println "faction: ${factionData.name}"
 				println "ih0    : ${influenceHistory[fromDate]}"


### PR DESCRIPTION
Hey, this pull request tries to handle retreats more gracefully.
Before this change it would show old data for a faction that has long retreated.
E.g. in Azrael today:

> Epsilon Hydri Commodities      None         1.80   0.30   0.80   0.80

while actually they retreated a few weeks ago.
With the update this gives:

> Epsilon Hydri Commodities      Gone         0.00   0.00   0.00   0.00

Eventually the entry will disappear when EDSM stops giving them as part of the historic data.